### PR TITLE
Ignore txes from p2p, include txes from dashd only

### DIFF
--- a/p2pool/dash/helper.py
+++ b/p2pool/dash/helper.py
@@ -109,5 +109,5 @@ def submit_block_rpc(block, ignore_failure, dashd, dashd_work, net):
         print >>sys.stderr, 'Block submittal result: %s (%r) Expected: %s' % (success, result, success_expected)
 
 def submit_block(block, ignore_failure, factory, dashd, dashd_work, net):
-    submit_block_rpc(block, ignore_failure, dashd, dashd_work, net)
     submit_block_p2p(block, factory, net)
+    submit_block_rpc(block, ignore_failure, dashd, dashd_work, net)

--- a/p2pool/dash/helper.py
+++ b/p2pool/dash/helper.py
@@ -109,5 +109,5 @@ def submit_block_rpc(block, ignore_failure, dashd, dashd_work, net):
         print >>sys.stderr, 'Block submittal result: %s (%r) Expected: %s' % (success, result, success_expected)
 
 def submit_block(block, ignore_failure, factory, dashd, dashd_work, net):
-    submit_block_p2p(block, factory, net)
     submit_block_rpc(block, ignore_failure, dashd, dashd_work, net)
+    submit_block_p2p(block, factory, net)

--- a/p2pool/dash/p2p.py
+++ b/p2pool/dash/p2p.py
@@ -72,10 +72,10 @@ class Protocol(p2protocol.Protocol):
     ])
     def handle_inv(self, invs):
         for inv in invs:
-            if inv['type'] == 'tx':
-                self.send_getdata(requests=[inv])
-            elif inv['type'] == 'block':
+            if inv['type'] == 'block':
                 self.factory.new_block.happened(inv['hash'])
+            # elif inv['type'] == 'tx':
+            #     self.send_getdata(requests=[inv])
             else:
                 if p2pool.DEBUG:
                     print 'Unneeded inv type', inv

--- a/p2pool/data.py
+++ b/p2pool/data.py
@@ -145,8 +145,8 @@ class Share(object):
             else:
                 if known_txs is not None:
                     this_size = dash_data.tx_type.packed_size(known_txs[tx_hash])
-                    if new_transaction_size + this_size > 50000: # only allow 50 kB of new txns/share
-                        break
+                    #if new_transaction_size + this_size > 50000: # only allow 50 kB of new txns/share
+                    #    break
                     new_transaction_size += this_size
                 new_transaction_hashes.append(tx_hash)
                 this = [0, len(new_transaction_hashes)-1]
@@ -379,9 +379,11 @@ class Share(object):
             if all_txs_size > 1000000:
                 return True, 'txs over block size limit'
             
+            '''
             new_txs_size = sum(dash_data.tx_type.packed_size(known_txs[tx_hash]) for tx_hash in self.share_info['new_transaction_hashes'])
             if new_txs_size > 50000:
                 return True, 'new txs over limit'
+            '''
         
         return False, None
     

--- a/p2pool/node.py
+++ b/p2pool/node.py
@@ -40,7 +40,7 @@ class P2PNode(p2p.Node):
             
             self.node.tracker.add(share)
         
-        self.node.known_txs_var.add(all_new_txs)
+        # self.node.known_txs_var.add(all_new_txs)
         
         if new_count:
             self.node.set_best_share()
@@ -270,6 +270,7 @@ class Node(object):
             print
             print 'GOT BLOCK FROM PEER! Passing to dashd! %s dash: %s%064x' % (p2pool_data.format_hash(share.hash), self.net.PARENT.BLOCK_EXPLORER_URL_PREFIX, share.header_hash)
             print
+            self.factory.new_block.happened(share.hash)
         
         def forget_old_txs():
             new_known_txs = {}

--- a/p2pool/p2p.py
+++ b/p2pool/p2p.py
@@ -449,7 +449,7 @@ class Protocol(p2protocol.Protocol):
             self.remembered_txs[tx_hash] = tx
             self.remembered_txs_size += 100 + dash_data.tx_type.packed_size(tx)
             added_known_txs[tx_hash] = tx
-        self.node.known_txs_var.add(added_known_txs)
+        # self.node.known_txs_var.add(added_known_txs)
         if self.remembered_txs_size >= self.max_remembered_txs_size:
             raise PeerMisbehavingError('too much transaction data stored')
     message_forget_tx = pack.ComposedType([

--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -102,6 +102,8 @@ class WorkerBridge(worker_interface.WorkerBridge):
             if bb is not None and bb['previous_block'] == t['previous_block'] and self.node.net.PARENT.POW_FUNC(dash_data.block_header_type.pack(bb)) <= t['bits'].target:
                 print 'Skipping from block %x to block %x! NewHeight=%s' % (bb['previous_block'],
                     self.node.net.PARENT.BLOCKHASH_FUNC(dash_data.block_header_type.pack(bb)),t['height']+1,)
+                '''
+                # New block template from Dash daemon only
                 t = dict(
                     version=bb['version'],
                     previous_block=self.node.net.PARENT.BLOCKHASH_FUNC(dash_data.block_header_type.pack(bb)),
@@ -117,6 +119,7 @@ class WorkerBridge(worker_interface.WorkerBridge):
                     payment_amount=self.node.dashd_work.value['payment_amount'],
                     packed_payments=self.node.dashd_work.value['packed_payments'],
                 )
+                '''
 
             self.current_work.set(t)
         self.node.dashd_work.changed.watch(lambda _: compute_work())
@@ -402,6 +405,8 @@ class WorkerBridge(worker_interface.WorkerBridge):
                         print
                         print 'GOT BLOCK FROM MINER! Passing to dashd! %s%064x' % (self.node.net.PARENT.BLOCK_EXPLORER_URL_PREFIX, header_hash)
                         print
+                        # New block found
+                        self.node.factory.new_block.happened(header_hash)
             except:
                 log.err(None, 'Error while processing potential block:')
 


### PR DESCRIPTION
It's appear that the submit_block_p2p and submit_block_rpc was called in wrong order compared to original p2pool. Possibly cause double submit block to Dash daemon.
So, this should solve #33 