### PR TITLE
Make it compatible with v0.15

### DIFF
--- a/p2pool/dash/networks/dash.py
+++ b/p2pool/dash/networks/dash.py
@@ -13,7 +13,7 @@ ADDRESS_VERSION = 76
 SCRIPT_ADDRESS_VERSION = 16
 RPC_PORT = 9998
 RPC_CHECK = defer.inlineCallbacks(lambda dashd: defer.returnValue(
-            'dash' in (yield dashd.rpc_help()) and
+            '== Dash ==' in (yield dashd.rpc_help()) and
             (yield dashd.rpc_getblockchaininfo())['chain'] == 'main'
         ))
 BLOCKHASH_FUNC = lambda data: pack.IntType(256).unpack(__import__('dash_hash').getPoWHash(data))

--- a/p2pool/dash/networks/dash_testnet.py
+++ b/p2pool/dash/networks/dash_testnet.py
@@ -13,7 +13,7 @@ ADDRESS_VERSION = 140
 SCRIPT_ADDRESS_VERSION = 19
 RPC_PORT = 19998
 RPC_CHECK = defer.inlineCallbacks(lambda dashd: defer.returnValue(
-            'dash' in (yield dashd.rpc_help()) and
+            '== Dash ==' in (yield dashd.rpc_help()) and
             (yield dashd.rpc_getblockchaininfo())['chain'] != 'main'
         ))
 BLOCKHASH_FUNC = lambda data: pack.IntType(256).unpack(__import__('dash_hash').getPoWHash(data))


### PR DESCRIPTION
We do not have `dashprivkey` in help text anymore so these checks fail. We do have `== Dash ==` (a set of Dash specific commands) in both v0.14 and v0.15 however.