### PR TITLE
Fix the start up check for newer versions of DASH and be consistent with

### DIFF
--- a/p2pool/dash/helper.py
+++ b/p2pool/dash/helper.py
@@ -119,3 +119,12 @@ def submit_block_rpc(block, ignore_failure, dashd, dashd_work, net):
 def submit_block(block, ignore_failure, factory, dashd, dashd_work, net):
     submit_block_rpc(block, ignore_failure, dashd, dashd_work, net)
     submit_block_p2p(block, factory, net)
+
+@defer.inlineCallbacks
+def check_block_header(bitcoind, block_hash):
+    try:
+        yield bitcoind.rpc_getblockheader(block_hash)
+    except jsonrpc.Error_for_code(-5):
+        defer.returnValue(False)
+    else:
+        defer.returnValue(True)

--- a/p2pool/dash/networks/dash.py
+++ b/p2pool/dash/networks/dash.py
@@ -13,7 +13,7 @@ ADDRESS_VERSION = 76
 SCRIPT_ADDRESS_VERSION = 16
 RPC_PORT = 9998
 RPC_CHECK = defer.inlineCallbacks(lambda dashd: defer.returnValue(
-            (yield helper.check_block_header(dashd, '000007d91d1254d60e2dd1ae580383070a4ddffa4c64c2eeb4a2f9ecc0414343')) and
+            (yield helper.check_block_header(dashd, '00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6')) and
             (yield dashd.rpc_getblockchaininfo())['chain'] == 'main'
         ))
 BLOCKHASH_FUNC = lambda data: pack.IntType(256).unpack(__import__('dash_hash').getPoWHash(data))

--- a/p2pool/dash/networks/dash.py
+++ b/p2pool/dash/networks/dash.py
@@ -13,7 +13,7 @@ ADDRESS_VERSION = 76
 SCRIPT_ADDRESS_VERSION = 16
 RPC_PORT = 9998
 RPC_CHECK = defer.inlineCallbacks(lambda dashd: defer.returnValue(
-            'dash' in (yield dashd.rpc_help()) and
+            (yield helper.check_block_header(dashd, '000007d91d1254d60e2dd1ae580383070a4ddffa4c64c2eeb4a2f9ecc0414343')) and
             (yield dashd.rpc_getblockchaininfo())['chain'] == 'main'
         ))
 BLOCKHASH_FUNC = lambda data: pack.IntType(256).unpack(__import__('dash_hash').getPoWHash(data))
@@ -21,8 +21,8 @@ POW_FUNC = lambda data: pack.IntType(256).unpack(__import__('dash_hash').getPoWH
 BLOCK_PERIOD = 150 # s
 SYMBOL = 'DASH'
 CONF_FILE_FUNC = lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'DashCore') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/DashCore/') if platform.system() == 'Darwin' else os.path.expanduser('~/.dashcore'), 'dash.conf')
-BLOCK_EXPLORER_URL_PREFIX = 'https://explorer.dash.org/block/'
-ADDRESS_EXPLORER_URL_PREFIX = 'https://explorer.dash.org/address/'
-TX_EXPLORER_URL_PREFIX = 'https://explorer.dash.org/tx/'
+BLOCK_EXPLORER_URL_PREFIX = 'https://chainz.cryptoid.info/dash/block.dws?'
+ADDRESS_EXPLORER_URL_PREFIX = 'https://chainz.cryptoid.info/dash/address.dws?'
+TX_EXPLORER_URL_PREFIX = 'https://chainz.cryptoid.info/dash/tx.dws?'
 SANE_TARGET_RANGE = (2**256//2**32//1000000 - 1, 2**256//2**32 - 1)
 DUST_THRESHOLD = 0.001e8

--- a/p2pool/dash/networks/dash_testnet.py
+++ b/p2pool/dash/networks/dash_testnet.py
@@ -13,7 +13,7 @@ ADDRESS_VERSION = 140
 SCRIPT_ADDRESS_VERSION = 19
 RPC_PORT = 19998
 RPC_CHECK = defer.inlineCallbacks(lambda dashd: defer.returnValue(
-            'dash' in (yield dashd.rpc_help()) and
+            (yield helper.check_block_header(dashd, '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c')) and
             (yield dashd.rpc_getblockchaininfo())['chain'] != 'main'
         ))
 BLOCKHASH_FUNC = lambda data: pack.IntType(256).unpack(__import__('dash_hash').getPoWHash(data))
@@ -21,8 +21,8 @@ POW_FUNC = lambda data: pack.IntType(256).unpack(__import__('dash_hash').getPoWH
 BLOCK_PERIOD = 150 # s
 SYMBOL = 'tDASH'
 CONF_FILE_FUNC = lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'DashCore') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/DashCore/') if platform.system() == 'Darwin' else os.path.expanduser('~/.dashcore'), 'dash.conf')
-BLOCK_EXPLORER_URL_PREFIX = 'https://test.explorer.dash.org/block/'
-ADDRESS_EXPLORER_URL_PREFIX = 'https://test.explorer.dash.org/address/'
-TX_EXPLORER_URL_PREFIX = 'https://test.explorer.dash.org/tx/'
+BLOCK_EXPLORER_URL_PREFIX = 'https://testnet-insight.dashevo.org/insight/block/'
+ADDRESS_EXPLORER_URL_PREFIX = 'https://testnet-insight.dashevo.org/insight/address/'
+TX_EXPLORER_URL_PREFIX = 'https://testnet-insight.dashevo.org/insight/address/'
 SANE_TARGET_RANGE = (2**256//2**32//1000000 - 1, 2**256//2**20 - 1)
 DUST_THRESHOLD = 0.001e8

--- a/p2pool/dash/networks/dash_testnet.py
+++ b/p2pool/dash/networks/dash_testnet.py
@@ -23,6 +23,6 @@ SYMBOL = 'tDASH'
 CONF_FILE_FUNC = lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'DashCore') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/DashCore/') if platform.system() == 'Darwin' else os.path.expanduser('~/.dashcore'), 'dash.conf')
 BLOCK_EXPLORER_URL_PREFIX = 'https://testnet-insight.dashevo.org/insight/block/'
 ADDRESS_EXPLORER_URL_PREFIX = 'https://testnet-insight.dashevo.org/insight/address/'
-TX_EXPLORER_URL_PREFIX = 'https://testnet-insight.dashevo.org/insight/address/'
+TX_EXPLORER_URL_PREFIX = 'https://testnet-insight.dashevo.org/insight/tx/'
 SANE_TARGET_RANGE = (2**256//2**32//1000000 - 1, 2**256//2**20 - 1)
 DUST_THRESHOLD = 0.001e8


### PR DESCRIPTION
other P2Pool implementations where they check the genesis block.
Change the block explorer links.